### PR TITLE
Fix: store Confidence as numeric in FST, remove downstream coercions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ www/temp_sound.wav
 /www
 .DS_Store
 .DS_Store
+.DS_Store

--- a/Scripts/birdomatic_UI.R
+++ b/Scripts/birdomatic_UI.R
@@ -91,7 +91,7 @@ file_score_ref <- all_data %>%
   group_by(Begin.Path) %>%
   summarise(
     ref_unique_species  = n_distinct(Common.Name),
-    ref_mean_confidence = mean(as.numeric(Confidence), na.rm = TRUE),
+    ref_mean_confidence = mean(Confidence, na.rm = TRUE),
     ref_avg_windspeed   = mean(avg_windspeed, na.rm = TRUE),
     .groups = "drop"
   ) %>%
@@ -991,7 +991,7 @@ server <- function(input, output, session) {
   confidence_filter <- function(data, conf) {
     min_conf <- conf[1]
     max_conf <- conf[2]
-    data <- subset(data, as.numeric(Confidence) >= min_conf & as.numeric(Confidence) <= max_conf)
+    data <- subset(data, Confidence >= min_conf & Confidence <= max_conf)
     return(data)
   } 
   
@@ -1420,9 +1420,9 @@ create_pivot_files <- function(df) {
       summarise(
         Number.Observations    = n(),
         Number.Unique.Species  = n_distinct(Common.Name),
-        Mean.Confidence        = as.numeric(format(round(mean(as.numeric(Confidence)), 4), nsmall = 4)),
-        Median.Confidence      = as.numeric(format(round(median(as.numeric(Confidence)), 4), nsmall = 4)),
-        SD.Confidence          = if (n()>1) as.numeric(format(round(sd(as.numeric(Confidence)), 4), nsmall = 4)) else 0,
+		Mean.Confidence   = as.numeric(format(round(mean(Confidence), 4), nsmall = 4)),
+		Median.Confidence = as.numeric(format(round(median(Confidence), 4), nsmall = 4)),
+		SD.Confidence     = if (n()>1) as.numeric(format(round(sd(Confidence), 4), nsmall = 4)) else 0,
         .groups = "drop"
       ) %>%
       mutate(Time = as_hms(Date.Time)) %>%
@@ -2154,8 +2154,8 @@ temp_query <- "
           ungroup()
         
         complete_data <- subset(complete_data,
-                                as.numeric(Confidence) >= min_conf &
-                                  as.numeric(Confidence) <= max_conf)
+          (Confidence) >= min_conf &
+          (Confidence) <= max_conf)
         
         count_data_week <- complete_data %>%
           group_by(Week.Year.Loc) %>%
@@ -2373,18 +2373,18 @@ temp_query <- "
       if (!is.null(selected_data())) {
         if (input$time_interval == "weekly") {
           out_df <- subset(complete_data, (Week.Year.Loc %in% selected_data()$key & 
-                                             as.numeric(Confidence)>=min_conf & 
-                                             as.numeric(Confidence)<= max_conf), select=c("Begin.Time..s.", "End.Time..s.", "Week", 
-                                                                                          "Confidence", "Location", "Begin.Path", "Species.Code", 
-                                                                                          "Date", "Common.Name", "Obs.Time", "avg_windspeed", "avg_temperature"))
+            (Confidence)>=min_conf & 
+            (Confidence)<= max_conf), select=c("Begin.Time..s.", "End.Time..s.", "Week", 
+              "Confidence", "Location", "Begin.Path", "Species.Code", 
+              "Date", "Common.Name", "Obs.Time", "avg_windspeed", "avg_temperature"))
         }
         
         if (input$time_interval == "monthly") {
           out_df <- subset(complete_data, (Month.Year.Loc %in% selected_data()$key & 
-                                             as.numeric(Confidence)>=min_conf & 
-                                             as.numeric(Confidence)<= max_conf), select=c("Begin.Time..s.", "End.Time..s.", "Week", 
-                                                                                          "Confidence", "Location", "Begin.Path", "Species.Code", 
-                                                                                          "Date", "Common.Name", "Obs.Time", "avg_windspeed", "avg_temperature"))
+            (Confidence)>=min_conf & 
+            (Confidence)<= max_conf), select=c("Begin.Time..s.", "End.Time..s.", "Week", 
+            "Confidence", "Location", "Begin.Path", "Species.Code", 
+            "Date", "Common.Name", "Obs.Time", "avg_windspeed", "avg_temperature"))
         }
         
         # Add action buttons for opening the website

--- a/Scripts/regenerate_FST.R
+++ b/Scripts/regenerate_FST.R
@@ -451,8 +451,16 @@
 	cat("PASS 1: Writing single-year FST file\n")
 	cat("========================================\n")
 	
+	# Enforce correct column types before writing.
+	# Confidence is read as character by read.table (colClasses="character")
+	# and converted to numeric early in the pipeline, but we enforce it
+	# here explicitly so the FST stores a numeric column and downstream
+	# consumers (birdomatic_UI.R) don't need repeated as.numeric() coercions.
+
+		closest_match$Confidence <- as.numeric(closest_match$Confidence)
+
 	# Save as a single-year .FST file
-	
+
 		write_fst(closest_match, single_year_fst_output)
 	
 	# Report results


### PR DESCRIPTION
- regenerate_FST.R: enforce Confidence as numeric before write_fst so FST stores numeric column rather than character
- birdomatic_UI.R: remove all as.numeric(Confidence) coercions now that column is correctly typed at source — affects confidence_filter, file_score_ref, create_pivot_files summarise block, and three additional filter locations
- Eliminates repeated string-to-number conversions on every filter operation, improving initial load performance